### PR TITLE
Only build docs.rs for `darwin` and `ios`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,9 @@ objc = "0.2"
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa = "0.24"
 core-graphics = "0.22"
+
+[package.metadata.docs.rs]
+targets = [
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+]


### PR DESCRIPTION
The [default set of targets] makes it so that the [current docs.rs page] defaults to `x86_64-unknown-linux-gnu` which is an empty page thanks to the module-level docs, and all other targets except `x86_64-apple-darwin` are also empty and wasteful to even show.

Of the default targets, leave only `x86_64-apple-darwin`, and add an iOS platform on the `aarch64-apple-ios` target, so that only documentation for relevant platforms is generated - and immediately visible on the crate home page.

[default set of targets]: https://docs.rs/about/metadata
[current docs.rs page]: https://docs.rs/raw-window-metal/0.3.0/raw_window_metal/index.html
