### PR TITLE
Upgrade raw-window-handle to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-engines", "graphics"]
 exclude = [".github/*"]
 
 [dependencies]
-raw-window-handle = "0.5.0"
+raw-window-handle = "0.6.0"
 objc = "0.2"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "macos", target_os = "ios"))]
+// #![cfg(any(target_os = "macos", target_os = "ios"))]
 #![allow(clippy::missing_safety_doc, clippy::let_unit_value)]
 
 #[macro_use]
@@ -14,5 +14,4 @@ pub type CAMetalLayer = *mut Object;
 pub enum Layer {
     Existing(CAMetalLayer),
     Allocated(CAMetalLayer),
-    None,
 }

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -2,26 +2,22 @@ use crate::{CAMetalLayer, Layer};
 use core_graphics::{base::CGFloat, geometry::CGRect};
 use objc::{
     msg_send,
-    runtime::{Object, BOOL, YES},
+    runtime::{BOOL, YES},
 };
 use raw_window_handle::UiKitWindowHandle;
-use std::{ffi::c_void, mem};
+use std::{ffi::c_void, ptr::NonNull};
 
 ///
 pub unsafe fn metal_layer_from_handle(handle: UiKitWindowHandle) -> Layer {
-    if !handle.ui_view.is_null() {
-        metal_layer_from_ui_view(handle.ui_view)
-    } else if !handle.ui_window.is_null() {
-        metal_layer_from_ui_window(handle.ui_window)
-    } else {
-        // TODO: ui_window & ui_view_controller support
-        Layer::None
+    if let Some(_ui_view_controller) = handle.ui_view_controller {
+        // TODO: ui_view_controller support
     }
+    metal_layer_from_ui_view(handle.ui_view)
 }
 
 ///
-pub unsafe fn metal_layer_from_ui_view(view: *mut c_void) -> Layer {
-    let view: cocoa::base::id = mem::transmute(view);
+pub unsafe fn metal_layer_from_ui_view(view: NonNull<c_void>) -> Layer {
+    let view: cocoa::base::id = view.cast().as_ptr();
     let main_layer: CAMetalLayer = msg_send![view, layer];
 
     let class = class!(CAMetalLayer);
@@ -50,11 +46,4 @@ pub unsafe fn metal_layer_from_ui_view(view: *mut c_void) -> Layer {
     }
 
     render_layer
-}
-
-///
-pub unsafe fn metal_layer_from_ui_window(window: *mut c_void) -> Layer {
-    let ui_window = window as *mut Object;
-    let ui_view = msg_send![ui_window, contentView];
-    metal_layer_from_ui_view(ui_view)
 }


### PR DESCRIPTION
There is no longer an `ns_window` member in the new handles, so support for it had to be dropped.  At the same time the `ns_view` members are appropriately marked `NonNull<>` so there's no longer a need for this fallback path.
