### PR TITLE
Use `objc2` and its framework crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 - Bump Rust Edition from 2018 to 2021.
+- Make `Layer`'s implementation details private; it is now a struct with `as_ptr` and `is_existing` accessor methods.
+- Add support for tvOS, watchOS and visionOS.
+- Use `objc2` internally.
 
 # 0.4.0 (2023-10-31)
 - Update `raw-window-handle` dep to `0.6.0`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,42 @@ exclude = [".github/*"]
 
 [dependencies]
 raw-window-handle = "0.6.0"
-objc = "0.2"
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-cocoa = "0.25"
-core-graphics = "0.23"
+[target.'cfg(target_vendor = "apple")'.dependencies]
+objc2 = "0.5.2"
+objc2-foundation = { version = "0.2.2", features = [
+    "NSObjCRuntime",
+    "NSGeometry",
+] }
+objc2-quartz-core = { version = "0.2.2", features = [
+    "CALayer",
+    "CAMetalLayer",
+    "objc2-metal",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.2.2", features = [
+    "NSResponder",
+    "NSView",
+    "NSWindow",
+    "objc2-quartz-core",
+] }
+
+[target.'cfg(all(target_vendor = "apple", not(target_os = "macos")))'.dependencies]
+objc2-ui-kit = { version = "0.2.2", features = [
+    "UIResponder",
+    "UIView",
+    "UIWindow",
+    "UIScreen",
+    "objc2-quartz-core",
+] }
 
 [package.metadata.docs.rs]
 targets = [
     "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
     "aarch64-apple-ios",
+    "aarch64-apple-ios-macabi",
+    "x86_64-apple-ios",
 ]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -18,7 +18,7 @@ pub unsafe fn metal_layer_from_ns_view(view: NonNull<c_void>) -> Layer {
     // SAFETY: Caller ensures that the view is valid.
     let obj = unsafe { view.cast::<NSObject>().as_ref() };
 
-    // Check if the view is a CAMetalLayer
+    // Check if the view is a `CAMetalLayer`.
     if obj.is_kind_of::<CAMetalLayer>() {
         // SAFETY: Just checked that the view is a `CAMetalLayer`.
         let layer = unsafe { view.cast::<CAMetalLayer>().as_ref() };
@@ -27,10 +27,10 @@ pub unsafe fn metal_layer_from_ns_view(view: NonNull<c_void>) -> Layer {
             pre_existing: true,
         };
     }
-    // Otherwise assume the view is `NSView`
+    // Otherwise assume the view is `NSView`.
     let view = unsafe { view.cast::<objc2_app_kit::NSView>().as_ref() };
 
-    // Check if the view contains a valid CAMetalLayer
+    // Check if the view contains a valid `CAMetalLayer`.
     let existing = unsafe { view.layer() };
     if let Some(existing) = existing {
         if existing.is_kind_of::<CAMetalLayer>() {
@@ -43,7 +43,7 @@ pub unsafe fn metal_layer_from_ns_view(view: NonNull<c_void>) -> Layer {
         }
     }
 
-    // If the layer was not `CAMetalLayer`, allocate a new one for the view
+    // If the layer was not `CAMetalLayer`, allocate a new one for the view.
     let layer = unsafe { CAMetalLayer::new() };
     unsafe { view.setLayer(Some(&layer)) };
     view.setWantsLayer(true);

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -8,12 +8,21 @@ use std::ptr::NonNull;
 
 use crate::Layer;
 
+/// Get or create a new [`Layer`] associated with the given
+/// [`AppKitWindowHandle`].
 ///
+/// # Safety
+///
+/// The handle must be valid.
 pub unsafe fn metal_layer_from_handle(handle: AppKitWindowHandle) -> Layer {
     unsafe { metal_layer_from_ns_view(handle.ns_view) }
 }
 
+/// Get or create a new [`Layer`] associated with the given `NSView`.
 ///
+/// # Safety
+///
+/// The view must be a valid instance of `NSView`.
 pub unsafe fn metal_layer_from_ns_view(view: NonNull<c_void>) -> Layer {
     // SAFETY: Caller ensures that the view is valid.
     let obj = unsafe { view.cast::<NSObject>().as_ref() };

--- a/src/appkit.rs
+++ b/src/appkit.rs
@@ -1,57 +1,61 @@
-use crate::{CAMetalLayer, Layer};
 use core::ffi::c_void;
-use core_graphics::{base::CGFloat, geometry::CGRect};
-use objc::{
-    msg_send,
-    runtime::{BOOL, YES},
-};
+use objc2::rc::Retained;
+use objc2::ClassType;
+use objc2_foundation::{NSObject, NSObjectProtocol};
+use objc2_quartz_core::CAMetalLayer;
 use raw_window_handle::AppKitWindowHandle;
 use std::ptr::NonNull;
 
+use crate::Layer;
+
 ///
 pub unsafe fn metal_layer_from_handle(handle: AppKitWindowHandle) -> Layer {
-    metal_layer_from_ns_view(handle.ns_view)
+    unsafe { metal_layer_from_ns_view(handle.ns_view) }
 }
 
 ///
 pub unsafe fn metal_layer_from_ns_view(view: NonNull<c_void>) -> Layer {
-    let view: cocoa::base::id = view.cast().as_ptr();
+    // SAFETY: Caller ensures that the view is valid.
+    let obj = unsafe { view.cast::<NSObject>().as_ref() };
 
     // Check if the view is a CAMetalLayer
-    let class = class!(CAMetalLayer);
-    let is_actually_layer: BOOL = msg_send![view, isKindOfClass: class];
-    if is_actually_layer == YES {
-        return Layer::Existing(view);
+    if obj.is_kind_of::<CAMetalLayer>() {
+        // SAFETY: Just checked that the view is a `CAMetalLayer`.
+        let layer = unsafe { view.cast::<CAMetalLayer>().as_ref() };
+        return Layer {
+            layer: layer.retain(),
+            pre_existing: true,
+        };
     }
+    // Otherwise assume the view is `NSView`
+    let view = unsafe { view.cast::<objc2_app_kit::NSView>().as_ref() };
 
     // Check if the view contains a valid CAMetalLayer
-    let existing: CAMetalLayer = msg_send![view, layer];
-    let use_current = if existing.is_null() {
-        false
-    } else {
-        let result: BOOL = msg_send![existing, isKindOfClass: class];
-        result == YES
-    };
-
-    let render_layer = if use_current {
-        Layer::Existing(existing)
-    } else {
-        // Allocate a new CAMetalLayer for the current view
-        let layer: CAMetalLayer = msg_send![class, new];
-        let () = msg_send![view, setLayer: layer];
-        let () = msg_send![view, setWantsLayer: YES];
-        let bounds: CGRect = msg_send![view, bounds];
-        let () = msg_send![layer, setBounds: bounds];
-
-        let window: cocoa::base::id = msg_send![view, window];
-        if !window.is_null() {
-            let scale_factor: CGFloat = msg_send![window, backingScaleFactor];
-            let () = msg_send![layer, setContentsScale: scale_factor];
+    let existing = unsafe { view.layer() };
+    if let Some(existing) = existing {
+        if existing.is_kind_of::<CAMetalLayer>() {
+            // SAFETY: Just checked that the layer is a `CAMetalLayer`.
+            let layer = unsafe { Retained::cast::<CAMetalLayer>(existing) };
+            return Layer {
+                layer,
+                pre_existing: true,
+            };
         }
+    }
 
-        Layer::Allocated(layer)
-    };
+    // If the layer was not `CAMetalLayer`, allocate a new one for the view
+    let layer = unsafe { CAMetalLayer::new() };
+    unsafe { view.setLayer(Some(&layer)) };
+    view.setWantsLayer(true);
+    layer.setBounds(view.bounds());
 
-    let _: *mut c_void = msg_send![view, retain];
-    render_layer
+    if let Some(window) = view.window() {
+        let scale_factor = window.backingScaleFactor();
+        layer.setContentsScale(scale_factor);
+    }
+
+    Layer {
+        layer,
+        pre_existing: false,
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,55 @@
-#![cfg(any(target_os = "macos", target_os = "ios"))]
-#![allow(clippy::missing_safety_doc, clippy::let_unit_value)]
+#![cfg(target_vendor = "apple")]
+#![allow(clippy::missing_safety_doc)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide), doc(cfg_hide(doc)))]
+#![deny(unsafe_op_in_unsafe_fn)]
 
-#[macro_use]
-extern crate objc;
+use objc2::rc::Retained;
+use objc2_quartz_core::CAMetalLayer;
+use std::ffi::c_void;
 
-use objc::runtime::Object;
-
+#[cfg(any(target_os = "macos", doc))]
 pub mod appkit;
+
+#[cfg(any(not(target_os = "macos"), doc))]
 pub mod uikit;
 
-pub type CAMetalLayer = *mut Object;
+/// A wrapper around [`CAMetalLayer`].
+pub struct Layer {
+    layer: Retained<CAMetalLayer>,
+    pre_existing: bool,
+}
 
-pub enum Layer {
-    Existing(CAMetalLayer),
-    Allocated(CAMetalLayer),
+impl Layer {
+    /// Get a pointer to the underlying [`CAMetalLayer`]. The pointer is valid
+    /// for at least as long as the [`Layer`] is valid, but can be extended by
+    /// retaining it.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use objc2::rc::Retained;
+    /// use objc2_quartz_core::CAMetalLayer;
+    /// use raw_window_metal::Layer;
+    ///
+    /// let layer: Layer;
+    /// # layer = unimplemented!();
+    ///
+    /// let layer: *mut CAMetalLayer = layer.as_ptr().cast();
+    /// // SAFETY: The pointer is a valid `CAMetalLayer`.
+    /// let layer = unsafe { Retained::retain(layer).unwrap() };
+    ///
+    /// // Use the `CAMetalLayer` here.
+    /// ```
+    #[inline]
+    pub fn as_ptr(&self) -> *mut c_void {
+        let ptr: *const CAMetalLayer = Retained::as_ptr(&self.layer);
+        ptr as *mut _
+    }
+
+    /// Whether `raw-window-metal` created a new [`CAMetalLayer`] for you.
+    #[inline]
+    pub fn pre_existing(&self) -> bool {
+        self.pre_existing
+    }
 }

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -5,7 +5,12 @@ use objc2_quartz_core::CAMetalLayer;
 use raw_window_handle::UiKitWindowHandle;
 use std::{ffi::c_void, ptr::NonNull};
 
+/// Get or create a new [`Layer`] associated with the given
+/// [`UiKitWindowHandle`].
 ///
+/// # Safety
+///
+/// The handle must be valid.
 pub unsafe fn metal_layer_from_handle(handle: UiKitWindowHandle) -> Layer {
     if let Some(_ui_view_controller) = handle.ui_view_controller {
         // TODO: ui_view_controller support
@@ -13,7 +18,11 @@ pub unsafe fn metal_layer_from_handle(handle: UiKitWindowHandle) -> Layer {
     unsafe { metal_layer_from_ui_view(handle.ui_view) }
 }
 
+/// Get or create a new [`Layer`] associated with the given `UIView`.
 ///
+/// # Safety
+///
+/// The view must be a valid instance of `UIView`.
 pub unsafe fn metal_layer_from_ui_view(view: NonNull<c_void>) -> Layer {
     // SAFETY: Caller ensures that the view is a `UIView`.
     let view = unsafe { view.cast::<objc2_ui_kit::UIView>().as_ref() };

--- a/src/uikit.rs
+++ b/src/uikit.rs
@@ -15,12 +15,12 @@ pub unsafe fn metal_layer_from_handle(handle: UiKitWindowHandle) -> Layer {
 
 ///
 pub unsafe fn metal_layer_from_ui_view(view: NonNull<c_void>) -> Layer {
-    // SAFETY: Caller ensures that the view is a UIView
+    // SAFETY: Caller ensures that the view is a `UIView`.
     let view = unsafe { view.cast::<objc2_ui_kit::UIView>().as_ref() };
 
     let main_layer = view.layer();
 
-    // Check if the view's layer is already a CAMetalLayer
+    // Check if the view's layer is already a `CAMetalLayer`.
     let render_layer = if main_layer.is_kind_of::<CAMetalLayer>() {
         // SAFETY: Just checked that the layer is a `CAMetalLayer`.
         let layer = unsafe { Retained::cast::<CAMetalLayer>(main_layer) };
@@ -29,11 +29,11 @@ pub unsafe fn metal_layer_from_ui_view(view: NonNull<c_void>) -> Layer {
             pre_existing: true,
         }
     } else {
-        // If the main layer is not a CAMetalLayer, we create a CAMetalLayer
-        // sublayer and use it instead.
+        // If the main layer is not a `CAMetalLayer`, we create a
+        // `CAMetalLayer` sublayer and use it instead.
         //
-        // Unlike on macOS, we cannot replace the main view as UIView does not
-        // allow it (when NSView does).
+        // Unlike on macOS, we cannot replace the main view as `UIView` does
+        // not allow it (when `NSView` does).
         let layer = unsafe { CAMetalLayer::new() };
 
         let bounds = main_layer.bounds();


### PR DESCRIPTION
[`objc2`](https://github.com/madsmtm/objc2) is a replacement for `objc`/`objc_id` that contains a bunch of safety improvements, including automatically generated type-safe APIs `objc2-foundation`/`objc2-app-kit`/`objc2-quartz-core`/`objc2-ui-kit` and `Id` which makes memory management very clear.

~This is currently a draft, as it uses yet-unreleased parts of `objc2-quartz-core`, as well as the unreleased `objc2-ui-kit` crate.~

Fixes https://github.com/norse-rs/raw-window-metal/issues/13.