### PR TITLE
Prepare for making the crate `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ keywords = ["window", "metal", "graphics"]
 categories = ["game-engines", "graphics"]
 exclude = [".github/*"]
 
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = "0.5.2"
 objc2-foundation = { version = "0.2.2", features = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@
 //! do not modify common `CALayer` properties of the layer that `raw-window-metal` creates, since
 //! they may just end up being overwritten (see also "Semantics" above).
 
+#![no_std]
 #![cfg(target_vendor = "apple")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide), doc(cfg_hide(doc)))]
 #![deny(unsafe_op_in_unsafe_fn)]
@@ -141,6 +142,12 @@ use objc2::{msg_send, rc::Retained};
 use objc2::{msg_send_id, ClassType};
 use objc2_foundation::{MainThreadMarker, NSObject, NSObjectProtocol};
 use objc2_quartz_core::{CALayer, CAMetalLayer};
+
+#[cfg(not(feature = "alloc"))]
+compile_error!("The `alloc` feature must currently be enabled.");
+
+#[cfg(not(feature = "std"))]
+compile_error!("The `std` feature must currently be enabled.");
 
 /// A wrapper around [`CAMetalLayer`].
 #[doc(alias = "CAMetalLayer")]


### PR DESCRIPTION
We can't do `#![no_std]` yet, because `objc2` does not support it, but once it does, we may need the `std` feature flag.

That means we have to add it now, otherwise we may break users that use `no-default-features = true`.

~Draft because it builds upon https://github.com/rust-windowing/raw-window-metal/pull/19.~