### PR TITLE
Add `Layer::into_raw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - Bump Rust Edition from 2018 to 2021.
-- Make `Layer`'s implementation details private; it is now a struct with `as_ptr` and `is_existing` accessor methods.
+- Make `Layer`'s implementation details private; it is now a struct with `as_ptr`, `into_raw` and `is_existing` accessor methods.
 - Add support for tvOS, watchOS and visionOS.
 - Use `objc2` internally.
 - Move `Layer` constructors to the type itself.


### PR DESCRIPTION
Allow consuming the `Layer`, which allows avoiding an unnecessary retain/release in the fairly common case where the user was going to retain anyhow.

~Draft because it builds upon https://github.com/rust-windowing/raw-window-metal/pull/19.~