### PR TITLE
Release v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Move `Layer` constructors to the type itself.
   - `appkit::metal_layer_from_ns_view` is now `Layer::from_ns_view`.
   - `uikit::metal_layer_from_ui_view` is now `Layer::from_ui_view`.
+
+  `raw-window-handle` types are also no longer exposed directly in the API.
+  This allows us to decouple the library from `raw-window-handle`'s versioning.
 - Added `Layer::from_layer` to construct a `Layer` from a `CALayer` directly.
 - Fixed layers not automatically resizing to match the super layer they were created from.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+# 1.0.0 (2024-09-09)
+
 - Bump Rust Edition from 2018 to 2021.
 - Make `Layer`'s implementation details private; it is now a struct with `as_ptr`, `into_raw` and `is_existing` accessor methods.
 - Add support for tvOS, watchOS and visionOS.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "raw-window-metal"
 # Remember to update html_root_url in lib.rs
-version = "0.4.0"
+version = "1.0.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Interop library between Metal and raw-window-handle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/raw-window-metal"
 repository = "https://github.com/rust-windowing/raw-window-metal"
 readme = "README.md"
 keywords = ["window", "metal", "graphics"]
-categories = ["game-engines", "graphics", "os::macos-apis"]
+categories = ["game-development", "graphics", "os::macos-apis"]
 exclude = [".github/*"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "raw-window-metal"
+# Remember to update html_root_url in lib.rs
 version = "0.4.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/raw-window-metal"
 repository = "https://github.com/rust-windowing/raw-window-metal"
 readme = "README.md"
 keywords = ["window", "metal", "graphics"]
-categories = ["game-engines", "graphics"]
+categories = ["game-engines", "graphics", "os::macos-apis"]
 exclude = [".github/*"]
 
 [features]

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@
 
 Interoperability library for Metal and [`raw-window-handle`](https://github.com/rust-windowing/raw-window-handle) for surface creation.
 
-```toml
-raw-window-metal = "0.4"
-```
-
 `CAMetalLayer` is the common entrypoint for graphics APIs (e.g `gfx` or `MoltenVK`), but the handles provided by window libraries may not include such a layer.
 This library may extract either this layer or allocate a new one.
+
+```console
+cargo add raw-window-metal
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This library may extract either this layer or allocate a new one.
 cargo add raw-window-metal
 ```
 
+See [the docs](https://docs.rs/raw-window-metal) for examples and further information.
+
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(clippy::undocumented_unsafe_blocks)]
 // Update in Cargo.toml as well.
-#![doc(html_root_url = "https://docs.rs/raw-window-metal/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/raw-window-metal/1.0.0")]
 
 mod observer;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide), doc(cfg_hide(doc)))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(clippy::undocumented_unsafe_blocks)]
+// Update in Cargo.toml as well.
+#![doc(html_root_url = "https://docs.rs/raw-window-metal/0.4.0")]
 
 mod observer;
 


### PR DESCRIPTION
I believe I can keep the API as it currently is stable for a long time. The only real outstanding question is https://github.com/rust-windowing/raw-window-metal/issues/24, which I haven't done enough research on to figure out (and isn't really motivated enough to do, it's quite niche), and I believe that can be solved without breaking changes.

The current API is even compatible with [future versions of `raw-window-handle` that may use different handles](https://github.com/rust-windowing/raw-window-handle/issues/123#issuecomment-2308505694).