### PR TITLE
Fix building on docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 
 #![no_std]
 #![cfg(target_vendor = "apple")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide), doc(cfg_hide(doc)))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(clippy::undocumented_unsafe_blocks)]
 // Update in Cargo.toml as well.


### PR DESCRIPTION
The `doc_auto_cfg` feature has been changed and renamed to `doc_cfg`.

This isn't an issue atm., but would be the next time we do a release.