### PR TITLE
Allow `ObserverLayer` to be defined multiple times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ std = ["alloc"]
 alloc = []
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
-objc2 = "0.6.0"
-objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
+objc2 = "0.6.4"
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
     "CFCGTypes",
 ] }
-objc2-foundation = { version = "0.3.0", default-features = false, features = [
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
     "objc2-core-foundation",
     "NSDictionary",
     "NSGeometry",
@@ -35,7 +35,7 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "NSThread",
     "NSValue",
 ] }
-objc2-quartz-core = { version = "0.3.0", default-features = false, features = [
+objc2-quartz-core = { version = "0.3.2", default-features = false, features = [
     "objc2-metal",
     "objc2-core-foundation",
     "CALayer",
@@ -46,13 +46,13 @@ objc2-quartz-core = { version = "0.3.0", default-features = false, features = [
 raw-window-handle = "0.6.0"
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
-objc2-app-kit = { version = "0.3.0", default-features = false, features = [
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "NSResponder",
     "NSView",
 ] }
 
 [target.'cfg(all(target_vendor = "apple", not(target_os = "macos")))'.dev-dependencies]
-objc2-ui-kit = { version = "0.3.0", default-features = false, features = [
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = [
     "UIResponder",
     "UIView",
 ] }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -25,7 +25,6 @@ define_class!(
     //   - It does not call an overridden method.
     //   - It does not `retain` itself.
     #[unsafe(super(CAMetalLayer))]
-    #[name = "RawWindowMetalLayer"]
     #[ivars = Weak<CALayer>]
     pub(crate) struct ObserverLayer;
 


### PR DESCRIPTION
If you use `raw-window-metal` multiple times across different dynamic libraries, and try to use these dynamic libraries together, we need to allow the observer layer class to be reused.

Fixes https://github.com/rust-windowing/raw-window-metal/issues/29, see that and https://github.com/madsmtm/objc2/issues/713 for discussion.